### PR TITLE
cross compile & sqlite

### DIFF
--- a/Redland-source/Mac/pp-configure.sh
+++ b/Redland-source/Mac/pp-configure.sh
@@ -29,4 +29,8 @@ export CXXFLAGS="$CFLAGS"
 
 export LDFLAGS="$ARCH -L$PREFIX/lib"
 
+# force sqlite use without pkg-config lookup
+export SQLITE_CFLAGS="-I${SDKROOT}/usr/include"
+export SQLITE_LIBS="-L${SDKROOT}/usr/lib -lsqlite3"
+
 ./configure --prefix="$PREFIX" ${confopts[@]}

--- a/Redland-source/cross-compile-config.py
+++ b/Redland-source/cross-compile-config.py
@@ -19,8 +19,11 @@ FLAGS = {
 	'raptor2-2.0.13': {
 		'*': ['--with-www=none'],
 	},
+	'rasqal-0.9.32': {
+		'*': ['--with-decimal=none'], # strangely configure picks up a mpfr from somewhere for OS X/Sim builds...
+	},
 	'redland-1.0.17': {
-		'*': ['--disable-modular', '--without-mysql', '--without-postgresql', '--without-virtuoso', '--without-bdb'],
+		'*': ['--disable-modular', '--without-sqlite=3', '--without-mysql', '--without-postgresql', '--without-virtuoso', '--without-bdb'],
 	},
 }
 

--- a/Redland-source/iOS/pp-configure.sh
+++ b/Redland-source/iOS/pp-configure.sh
@@ -95,6 +95,10 @@ export CPPFLAGS="$CFLAGS"
 export CXXFLAGS="$CFLAGS"
 export LDFLAGS="--sysroot=$SDKROOT -isysroot $SDKROOT -L${SDKROOT}/usr/lib/system -L${SDKROOT}/usr/lib -L${PREFIX}/lib"
 
+# force sqlite use without pkg-config lookup
+export SQLITE_CFLAGS="-I${SDKROOT}/usr/include"
+export SQLITE_LIBS="-L${SDKROOT}/usr/lib -lsqlite3"
+
 # set paths
 export CC=/usr/bin/gcc		# used to be "${DEVROOT}/usr/bin/gcc", but Xcode 5 no longer bundles gcc for iPhoneOS.platform
 unset CPP					# configure uses "$CC -E" if CPP is not set, which is needed for many configure scripts. So, DON'T set CPP


### PR DESCRIPTION
- force configure to use sqlite from platform sdk,
- force configure to not use mpfr.

fixes https://github.com/p2/Redland-ObjC/issues/11
