### PR TITLE
Fix for properly build libraries for Simulator 

### DIFF
--- a/Redland-source/Sim/pp-configure.sh
+++ b/Redland-source/Sim/pp-configure.sh
@@ -1,6 +1,23 @@
 #!/bin/bash
 
-export MACOSX_DEPLOYMENT_TARGET="10.6"
+#
+#	This script runs the GNU Autotools created "./configure" script in order to
+#	cross compile C libraries for iOS.
+#
+#	Easiest is to place this script in your $PATH, e.g. /usr/local/bin, and run
+#	"ios-configure -arch armv7" instead of "./configure". You can also specify
+#	your own prefix with --prefix=/usr/mybuild. By default, the libraries will
+#	be installed into "/usr/local/ios-x.x"
+#	Afterwards, just run "make" and "sudo make install". 
+#
+#	If you want fat libraries, you'll need to run this script for all archs
+#	you want to build for and then use `lipo` to combine the static libs. Some
+#	libraries may compile just fine if you specify multiple archs.
+#
+#	This script has last been tested with Xcode 4.4 and 4.5-DP4 on OS X 10.8
+#
+
+export IPHONEOS_DEPLOYMENT_TARGET="6.0"
 
 # extract command line arguments
 archs=()
@@ -20,17 +37,80 @@ if [[ 'x' = ${ARCH}x ]]; then
 	ARCH="-arch i386"
 fi
 
+if [[ 'x' = ${PLATFORM_NAME}x ]]; then
+	PLATFORM_NAME='iPhoneSimulator'
+fi
+
+# clean up
+unset CPATH
+unset C_INCLUDE_PATH
+unset CPLUS_INCLUDE_PATH
+unset OBJC_INCLUDE_PATH
+unset LIBS
+unset DYLD_FALLBACK_LIBRARY_PATH
+unset DYLD_FALLBACK_FRAMEWORK_PATH
+
+# determine Dev-Root
+export HOST_DARWIN_VER=$(uname -r)
+export HOST_ARCH=$(uname -m)
+if [[ 'x' != ${DEVELOPER_DIR}x ]]; then
+	export XCODE=$DEVELOPER_DIR
+else
+	export XCODE="$(xcode-select --print-path)"
+fi
+export DEVROOT="${XCODE}/Platforms/${PLATFORM_NAME}.platform/Developer"
+
+if [ ! -d "$DEVROOT" ]; then
+	echo "There is no SDK at \"$DEVROOT\""
+	exit 1
+fi
+
+# determine SDK-root and -version
+if [[ 'x' = ${SDKVER}x ]]; then
+	LATEST=$(ls -1r "$DEVROOT/SDKs/" | head -1)
+	export SDKROOT="${DEVROOT}/SDKs/$LATEST"
+	SDKVER='7.1'
+else
+	export SDKROOT="${DEVROOT}/SDKs/${PLATFORM_NAME}${SDKVER}.sdk"
+fi
+
+if [ ! -d "$SDKROOT" ] ; then
+	echo "The SDK could not be found. Directory \"$SDKROOT\" does not exist."
+	exit 1
+fi
+
 if [[ 'x' = ${PREFIX}x ]]; then
-	PREFIX=/usr/local
+	PREFIX="/usr/local/ios-$SDKVER"
 fi
 export PREFIX
 
-export PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig:/usr/local/lib/pkgconfig:/usr/lib/pkgconfig"
+# pkg-config
+#export PKG_CONFIG="$SDKROOT/usr/lib/pkgconfig"
+export PKG_CONFIG_PATH="${SDKROOT}/usr/lib/pkgconfig:${DEVROOT}/usr/lib/pkgconfig:${PREFIX}/lib/pkgconfig"
+#export PKG_CONFIG_LIBDIR="$PKG_CONFIG"
 
-export CFLAGS="-std=c99 $ARCH -pipe -I$PREFIX/include"
+# set flags
+export CFLAGS="-miphoneos-version-min=$SDKVER -std=c99 $ARCH -pipe --sysroot=$SDKROOT -isysroot $SDKROOT -I${SDKROOT}/usr/include -I${DEVROOT}/usr/include -I${PREFIX}/include"
 export CPPFLAGS="$CFLAGS"
 export CXXFLAGS="$CFLAGS"
 
-export LDFLAGS="$ARCH -L$PREFIX/lib"
+export LDFLAGS="-miphoneos-version-min=$SDKVER --sysroot=$SDKROOT -isysroot $SDKROOT -L${SDKROOT}/usr/lib/system -L${SDKROOT}/usr/lib -L${PREFIX}/lib"
 
-./configure --prefix="$PREFIX" ${confopts[@]}
+# set paths
+export CC=/usr/bin/gcc		# used to be "${DEVROOT}/usr/bin/gcc", but Xcode 5 no longer bundles gcc for iPhoneOS.platform
+unset CPP					# configure uses "$CC -E" if CPP is not set, which is needed for many configure scripts. So, DON'T set CPP
+#export CPP="${DEVROOT}/usr/bin/c++"
+#export CXX="$CPP"
+#export CXXCPP="$CPP"
+
+# compilation works for me without setting the following paths
+#export LD="${DEVROOT}/usr/bin/ld"
+#export STRIP="${DEVROOT}/usr/bin/strip"
+#export AS="${DEVROOT}/usr/bin/as"
+#export ASCPP="$AS"
+#export AR="${DEVROOT}/usr/bin/ar"
+#export RANLIB="${DEVROOT}/usr/bin/ranlib"
+
+
+# run ./configure
+./configure --prefix="$PREFIX" --build="${HOST_ARCH}-apple-darwin${HOST_DARWIN_VER}" --host="${HOST_ARCH}-apple-darwin" --enable-static --disable-shared ac_cv_file__dev_zero=no ac_cv_func_setpgrp_void=yes ${confopts[@]}

--- a/Redland-source/cross-compile-config.py
+++ b/Redland-source/cross-compile-config.py
@@ -11,7 +11,7 @@ SOURCES = [
 
 ARCHS = {
 	'iOS': ['armv7', 'armv7s', 'arm64'],
-	#'Sim': ['i386', 'x86_64'],		disable as we can just use the "Mac" build these days
+	'Sim': ['i386', 'x86_64'],
 	'Mac': ['i386', 'x86_64']
 }
 


### PR DESCRIPTION
The current versions of libraptor2.a, librasqal2.lib, librdf.a could not be used with iOS Simulator.
The linker throws errors like "Could not found fopen$UNIX2003" and etc.
